### PR TITLE
implementation of `PawTheme` and a `DarkTheme` preset for easier customizations

### DIFF
--- a/lib/src/themes/core/interface.theme.paw.dart
+++ b/lib/src/themes/core/interface.theme.paw.dart
@@ -1,0 +1,78 @@
+import '../../colors/ansi.paw.dart';
+
+///
+/// `PawTheme` - An abstract class to help create custom themes to
+/// customize Paw
+///
+abstract class PawTheme {
+  // text colors
+
+  ///
+  /// A foreground color to represent the primary text in the log, such as
+  /// log level heading, source file info, timing, etc.
+  ///
+  AnsiForegroundColors get heading;
+
+  ///
+  /// A foreground color to represent the secondary text in the log, this is
+  /// the message that is being printed with the log
+  ///
+  AnsiForegroundColors get message;
+
+  ///
+  /// A foreground color to represent the tertiary text in the log, such as
+  /// stacktrace, debugging object, etc.
+  ///
+  AnsiForegroundColors get object;
+
+  // accent colors
+
+  ///
+  /// A foreground color to represent the error message in the log
+  ///
+  AnsiForegroundColors get errorMessage;
+
+  ///
+  /// A foreground color to represent the error object in the log
+  ///
+  AnsiForegroundColors get errorObject;
+
+  // bg colors
+
+  ///
+  /// A background color for the WARN log
+  ///
+  AnsiBackgroundColor get bgWarn;
+
+  ///
+  /// A background color for the INFO log
+  ///
+  AnsiBackgroundColor get bgInfo;
+
+  ///
+  /// A background color for the TRACE log
+  ///
+  AnsiBackgroundColor get bgTrace;
+
+  ///
+  /// A background color for the DEBUG log
+  ///
+  AnsiBackgroundColor get bgDebug;
+
+  ///
+  /// A background color for the ERROR log
+  ///
+  AnsiBackgroundColor get bgError;
+
+  ///
+  /// A background color for the FETAL log
+  ///
+  AnsiBackgroundColor get bgFetal;
+
+  ///
+  /// A background color for info card,
+  ///
+  /// Info card include info like source file info and time of the log
+  ///
+  AnsiBackgroundColor get infoCardBg;
+}

--- a/lib/src/themes/dark.theme.paw.dart
+++ b/lib/src/themes/dark.theme.paw.dart
@@ -1,0 +1,49 @@
+import '../colors/ansi.paw.dart';
+import 'core/interface.theme.paw.dart';
+
+///
+/// A custom theme preset to customize Paw logging with a dark theme
+///
+class DarkTheme extends PawTheme {
+  // text colors
+
+  @override
+  AnsiForegroundColors get heading => AnsiForegroundColors.white;
+
+  @override
+  AnsiForegroundColors get message => AnsiForegroundColors.softPink;
+
+  @override
+  AnsiForegroundColors get object => AnsiForegroundColors.lightPurple;
+
+  // accent colors
+
+  @override
+  AnsiForegroundColors get errorMessage => AnsiForegroundColors.orange;
+
+  @override
+  AnsiForegroundColors get errorObject => AnsiForegroundColors.red;
+
+  // background colors
+
+  @override
+  AnsiBackgroundColor get bgDebug => AnsiBackgroundColor.gray;
+
+  @override
+  AnsiBackgroundColor get bgError => AnsiBackgroundColor.darkPink;
+
+  @override
+  AnsiBackgroundColor get bgFetal => AnsiBackgroundColor.maroon;
+
+  @override
+  AnsiBackgroundColor get bgInfo => AnsiBackgroundColor.blue;
+
+  @override
+  AnsiBackgroundColor get bgTrace => AnsiBackgroundColor.green;
+
+  @override
+  AnsiBackgroundColor get bgWarn => AnsiBackgroundColor.pink;
+
+  @override
+  AnsiBackgroundColor get infoCardBg => AnsiBackgroundColor.lightGray;
+}


### PR DESCRIPTION
Implemented a way to create custom themes in `Paw` to customize logging.
Created a `DarkTheme` preset to be the default theme of Paw

Completed - #8 